### PR TITLE
Update installation docs to match readme

### DIFF
--- a/src/routes/installation/+page.svelte
+++ b/src/routes/installation/+page.svelte
@@ -6,7 +6,10 @@
 
 	const tailwindCode = `
 module.exports = {
-	content: ['./src/**/*.{html,js,svelte,ts}'],
+	content: [
+		'./src/**/*.{html,js,svelte,ts}',
+		'./node_modules/stwui/**/*.{svelte,js,ts,html}
+	],
 	plugins: [
 		require('@tailwindcss/forms'),
 		require('stwui/plugin')


### PR DESCRIPTION
Added tailwind config for finding stwui content so that the readme guidance matches what we see in the web doc site. Low priority for sure because you are going to rework the docs.