### PR TITLE
feat(Select): Added multiselect and unselect

### DIFF
--- a/src/lib/components/select/Option.svelte
+++ b/src/lib/components/select/Option.svelte
@@ -14,7 +14,7 @@
 
 	export let option: string;
 
-	const value: Writable<string> = getContext('select-value');
+	const values: Writable<string[]> = getContext('select-values');
 	const handleSelect: (option: string) => void = getContext('select-handleSelect');
 
 	const defaultClass =
@@ -25,18 +25,18 @@
 <li
 	class={finalClass}
 	role="option"
-	aria-selected={option === $value}
+	aria-selected={$values.includes(option)}
 	use:useActions={use}
 	use:forwardEvents
 	{...exclude($$props, ['use', 'class'])}
 >
 	<button aria-label="select option" on:click={() => handleSelect(option)} class="w-full text-left">
 		<div class="relative py-1.5 pl-2.5 pr-7 w-full rounded-md overflow-hidden">
-			<span class="font-normal block truncate" class:font-semibold={option === $value}>
+			<span class="font-normal block truncate" class:font-semibold={$values.includes(option)}>
 				{option}
 			</span>
 
-			{#if option === $value}
+			{#if $values.includes(option)}
 				<span
 					transition:scale|local
 					class="text-primary absolute inset-y-0 right-0 flex items-center pr-1.5"

--- a/src/routes/select/+page.svelte
+++ b/src/routes/select/+page.svelte
@@ -14,9 +14,9 @@
 
 	const options = ['Option 1', 'Option 2', 'Option 3'];
 
-	let value: string | undefined;
+	let values: string[] | undefined;
 	let error: string | undefined = "You're doing it wrong!";
-	$: if (value && value.length > 0) {
+	$: if (values && values.length > 0) {
 		error = undefined;
 	} else {
 		error = "You're doing it wrong!";
@@ -26,7 +26,7 @@
 <Col class="col-24 md:col-12">
 	<Card bordered={false}>
 		<Card.Content slot="content" class="p-4">
-			<Select name="select-1" placeholder="Basic">
+			<Select name="select-1" placeholder="Basic" multiselect>
 				<Select.Options slot="options">
 					{#each options as option}
 						<Select.Options.Option {option} />
@@ -44,7 +44,7 @@
 				</Select.Options>
 			</Select>
 			<br />
-			<Select name="select-3" {error} bind:value>
+			<Select name="select-3" {error} bind:values>
 				<Select.Label slot="label">Label</Select.Label>
 				<Select.Leading slot="leading" data={email} />
 				<Select.Options slot="options">

--- a/src/routes/select/examples.ts
+++ b/src/routes/select/examples.ts
@@ -134,16 +134,16 @@ export const example = `
 	const email = "svg-path";
 	const options = ['Option 1', 'Option 2', 'Option 3'];
 
-	let value: string | undefined;
+	let values: string[] | undefined;
 	let error: string | undefined = "You're doing it wrong!";
-	$: if (value && value.length > 0) {
+	$: if (values && values.length > 0) {
 		error = undefined;
 	} else {
 		error = "You're doing it wrong!";
 	}
 </script>
 
-<Select name="select-1" placeholder="Basic">
+<Select name="select-1" placeholder="Basic" multiselect>
 	<Select.Options slot="options">
 		{#each options as option}
 			<Select.Options.Option {option} />
@@ -161,7 +161,7 @@ export const example = `
 	</Select.Options>
 </Select>
 
-<Select name="select-3" {error} bind:value>
+<Select name="select-3" {error} bind:values>
 	<Select.Label slot="label">Label</Select.Label>
 	<Select.Leading slot="leading" data={email} />
 	<Select.Options slot="options">

--- a/src/routes/select/examples.ts
+++ b/src/routes/select/examples.ts
@@ -21,13 +21,19 @@ export const props: Prop[] = [
 	},
 	{
 		id: '4',
-		prop: 'value',
-		type: 'string | undefined',
-		default: ''
+		prop: 'values',
+		type: 'string[] | undefined',
+		default: '[]'
 	},
 	{
 		id: '5',
 		prop: 'visible',
+		type: 'boolean',
+		default: 'false'
+	},
+	{
+		id: '6',
+		prop: 'multiselect',
 		type: 'boolean',
 		default: 'false'
 	}


### PR DESCRIPTION
I felt like it would be great if the `Select` component could optionally be used as a multi-select too.

To do this, I basically changed everything to use an array of values instead of a string, which I concede is a bit more work for people only using the single selection but I didn't want to go ahead and create disjunctive props.

I also updated the example.