### PR TITLE
fix(chekbox): added disabled + checked props

### DIFF
--- a/src/lib/components/checkbox/Checkbox.svelte
+++ b/src/lib/components/checkbox/Checkbox.svelte
@@ -5,15 +5,21 @@
 	export let name: string;
 	export let value: string;
 	export let indeterminate = false;
+	export let checked = false;
+	export let disabled = false;
 
 	const defaultClass =
-		'checkbox checked:bg-primary dark:checked:bg-primary indeterminate:bg-primary dark:indeterminate:bg-primary hover:border-primary dark:hover:border-primary bg-light-surface dark:bg-dark-surface h-6 w-6 text-primary border-light-border-base dark:border-dark-border-base rounded-md cursor-pointer';
+		'checkbox checked:bg-primary dark:checked:bg-primary indeterminate:bg-primary dark:indeterminate:bg-primary hover:border-primary dark:hover:border-primary bg-light-surface dark:bg-dark-surface h-6 w-6 text-primary border-light-border-base dark:border-dark-border-base rounded-md cursor-pointer disabled:checked:bg-gray-300 dark:disabled:checked:bg-zinc-600';
 	$: finalClass = twMerge(defaultClass, $$props.class);
 
 	setContext('checkbox-name', name);
 </script>
 
-<div class="relative flex items-start">
+<div
+	class="relative flex items-start"
+	class:pointer-events-none={disabled}
+	class:opacity-50={disabled}
+>
 	<div class="flex items-center h-5">
 		<input
 			id={name}
@@ -23,6 +29,8 @@
 			{value}
 			class={finalClass}
 			style={$$props.style}
+			{checked}
+			{disabled}
 		/>
 	</div>
 	<div class="ml-3 text-sm">

--- a/src/routes/checkbox/+page.svelte
+++ b/src/routes/checkbox/+page.svelte
@@ -10,7 +10,9 @@
 		checkboxProps,
 		checkboxSlots,
 		labelSlots,
-		descriptionSlots
+		descriptionSlots,
+		disabledExample,
+		defaultCheckedExample
 	} from './examples';
 	import { PropsTable, SlotsTable, CodeBlock } from '../../docs';
 </script>
@@ -115,6 +117,43 @@
 			<br />
 
 			<CodeBlock language="svelte" code={inlineExample} />
+		</Card.Content>
+	</Card>
+</Col>
+
+<Col class="col-24 md:col-12">
+	<Card bordered={false}>
+		<Card.Header slot="header">Default checked</Card.Header>
+		<Card.Content slot="content" class="p-4">
+			<CheckboxGroup>
+				<CheckboxGroup.Checkbox name="cb-19" value="cb-19" checked={true}>
+					<CheckboxGroup.Checkbox.Label slot="label">Checkbox-19</CheckboxGroup.Checkbox.Label>
+				</CheckboxGroup.Checkbox>
+			</CheckboxGroup>
+
+			<br />
+
+			<CodeBlock language="svelte" code={defaultCheckedExample} />
+		</Card.Content>
+	</Card>
+</Col>
+
+<Col class="col-24 md:col-12">
+	<Card bordered={false}>
+		<Card.Header slot="header">Disabled</Card.Header>
+		<Card.Content slot="content" class="p-4">
+			<CheckboxGroup>
+				<CheckboxGroup.Checkbox name="cb-17" value="cb-17" disabled={true}>
+					<CheckboxGroup.Checkbox.Label slot="label">Checkbox-17</CheckboxGroup.Checkbox.Label>
+				</CheckboxGroup.Checkbox>
+				<CheckboxGroup.Checkbox name="cb-18" value="cb-18" disabled={true} checked={true}>
+					<CheckboxGroup.Checkbox.Label slot="label">Checkbox-18</CheckboxGroup.Checkbox.Label>
+				</CheckboxGroup.Checkbox>
+			</CheckboxGroup>
+
+			<br />
+
+			<CodeBlock language="svelte" code={disabledExample} />
 		</Card.Content>
 	</Card>
 </Col>

--- a/src/routes/checkbox/examples.ts
+++ b/src/routes/checkbox/examples.ts
@@ -48,6 +48,18 @@ export const checkboxProps: Prop[] = [
 		prop: 'indeterminate',
 		type: 'boolean',
 		default: 'false'
+	},
+	{
+		id: '4',
+		prop: 'disabled',
+		type: 'boolean',
+		default: 'false'
+	},
+	{
+		id: '5',
+		prop: 'checked',
+		type: 'boolean',
+		default: 'false'
 	}
 ];
 
@@ -169,4 +181,29 @@ export const inlineExample = `
          desc-16
       </CheckboxGroup.Checkbox.Description>
    </CheckboxGroup.Checkbox>
+</CheckboxGroup>`;
+
+export const disabledExample = `
+<script lang="ts">
+	import { CheckboxGroup } from 'stwui';
+</script>
+
+<CheckboxGroup>
+	<CheckboxGroup.Checkbox name="cb-17" value="cb-17" disabled={true}>
+			<CheckboxGroup.Checkbox.Label slot="label">Checkbox-17</CheckboxGroup.Checkbox.Label>
+	</CheckboxGroup.Checkbox>
+	<CheckboxGroup.Checkbox name="cb-18" value="cb-18" disabled={true} checked={true}>
+			<CheckboxGroup.Checkbox.Label slot="label">Checkbox-18</CheckboxGroup.Checkbox.Label>
+	</CheckboxGroup.Checkbox>
+</CheckboxGroup>`;
+
+export const defaultCheckedExample = `
+<script lang="ts">
+	import { CheckboxGroup } from 'stwui';
+</script>
+
+<CheckboxGroup>
+	<CheckboxGroup.Checkbox name="cb-19" value="cb-19" checked={true}>
+			<CheckboxGroup.Checkbox.Label slot="label">Checkbox-19</CheckboxGroup.Checkbox.Label>
+	</CheckboxGroup.Checkbox>
 </CheckboxGroup>`;


### PR DESCRIPTION
As per issue #99, i have added disabled and checked props to the Checkbox component.

**Whats changed**

- Checkbox now exports "disabled" and "checked" props
- Added styling for disabled state
- Added docs showing "disabled" and "checked" states.

Im still unsure how to handle compound variations in this project, currently i just used the "class:" syntax thats come by default in Svelte, but i would like some feedback on that.

Im happy to hear your toughts. 👍 