### PR TITLE
fix(Input): do not show text under password eye icon

### DIFF
--- a/src/lib/components/input/Input.svelte
+++ b/src/lib/components/input/Input.svelte
@@ -85,7 +85,7 @@
 			class:group-active:not(.disable-focus-active):border-primary={!error}
 			class:bg-default={disabled}
 			class:pl-10={$$slots.leading}
-			class:pr-10={$$slots.trailing || error || allowClear}
+			class:pr-10={$$slots.trailing || error || allowClear || type === 'password'}
 			{placeholder}
 			bind:value
 			use:useActions={use}


### PR DESCRIPTION
This PR adds right padding to the input field if it's type `password`.

Before:
![image](https://github.com/N00nDay/stwui/assets/63594396/44166f97-6d04-4137-8c13-8b986b3b9808)
![image](https://github.com/N00nDay/stwui/assets/63594396/468b99e5-d3de-490e-acfd-97b1a413ca2c)

After:
![image](https://github.com/N00nDay/stwui/assets/63594396/9699b14b-f130-4b12-bbd7-f22d587832e9)
![image](https://github.com/N00nDay/stwui/assets/63594396/bfa6b900-829e-4480-af3b-7c09f03f2aac)
