### PR TITLE
Make Slider component two-way bindable

### DIFF
--- a/src/lib/components/slider/Slider.svelte
+++ b/src/lib/components/slider/Slider.svelte
@@ -170,7 +170,7 @@
 		{min}
 		{max}
 		{step}
-		{value}
+		bind:value
 		{disabled}
 		class={finalClass}
 		class:default={disabled}


### PR DESCRIPTION
I'm no Svelte guru, but it seems the shorthand `{value}` is a one-way binding. This simple change is to make the slider component emit value changes. 