### PR TITLE
feat(Menu): add itemsPanelClass prop for Group

### DIFF
--- a/src/lib/components/menu/Group.svelte
+++ b/src/lib/components/menu/Group.svelte
@@ -14,6 +14,7 @@
 
 	export let label: string;
 	export let key: string;
+	export let itemsPanelClass = '';
 
 	let active = false;
 	let collapsable: HTMLButtonElement;
@@ -63,6 +64,7 @@
 
 	const defaultClass = 'transition-all duration-300 stwui-menu-group';
 	$: finalClass = twMerge(defaultClass, $$props.class);
+	$: itemsPanelFinalClass = twMerge('space-y-1 pt-1', itemsPanelClass);
 
 	setContext('menu-group-key', key);
 </script>
@@ -119,7 +121,7 @@
 			out:transition|local={{}}
 		>
 			<div
-				class="space-y-1 pt-1"
+				class={itemsPanelFinalClass}
 				class:p-1={$menuCollapse}
 				class:border={$menuCollapse}
 				class:border-border={$menuCollapse}

--- a/src/routes/menu/examples.ts
+++ b/src/routes/menu/examples.ts
@@ -126,6 +126,12 @@ export const groupProps: Prop[] = [
 		prop: 'label',
 		type: 'string',
 		default: ''
+	},
+	{
+		id: '3',
+		prop: 'itemsPanelClass',
+		type: 'string',
+		default: ''
 	}
 ];
 


### PR DESCRIPTION
Would be great to have a way to control items panel class. In my case I need to have it scrollable if too many items items exist.
![image](https://github.com/N00nDay/stwui/assets/1155245/b3a6b343-67e7-4338-8864-b125454753aa)
