### PR TITLE
fix(Toggle): if content on one side only then clicking toggles

### DIFF
--- a/src/lib/components/toggle/ContentLeft.svelte
+++ b/src/lib/components/toggle/ContentLeft.svelte
@@ -8,7 +8,7 @@
 	const forwardEvents = forwardEventsBuilder(get_current_component());
 
 	const name: string = getContext('toggle-name');
-	const toggleOff: () => void = getContext('toggle-off');
+	const click: () => void = getContext('toggle-click-content-left');
 
 	const defaultClass = 'mr-3 cursor-pointer stwui-toggle-content-left';
 	$: finalClass = twMerge(defaultClass, $$props.class);
@@ -19,7 +19,7 @@
 	tabindex="-1"
 	id="{name}-label-left"
 	class={finalClass}
-	on:click={toggleOff}
+	on:click={click}
 	use:useActions={use}
 	use:forwardEvents
 	{...exclude($$props, ['use', 'class', 'id', 'on:click'])}

--- a/src/lib/components/toggle/ContentRight.svelte
+++ b/src/lib/components/toggle/ContentRight.svelte
@@ -8,7 +8,7 @@
 	const forwardEvents = forwardEventsBuilder(get_current_component());
 
 	const name: string = getContext('toggle-name');
-	const toggleOn: () => void = getContext('toggle-on');
+	const click: () => void = getContext('toggle-click-content-right');
 
 	const defaultClass = 'ml-3 cursor-pointer stwui-toggle-content-right';
 	$: finalClass = twMerge(defaultClass, $$props.class);
@@ -19,7 +19,7 @@
 	tabindex="-1"
 	id="{name}-label-right"
 	class={finalClass}
-	on:click={toggleOn}
+	on:click={click}
 	use:useActions={use}
 	use:forwardEvents
 	{...exclude($$props, ['use', 'class', 'id', 'on:click'])}

--- a/src/lib/components/toggle/Toggle.svelte
+++ b/src/lib/components/toggle/Toggle.svelte
@@ -25,20 +25,20 @@
 		on = !on;
 	}
 
-	function toggleOn() {
-		on = true;
+	function clickContentLeft() {
+		on = $$slots['content-right'] ? false : !on;
 	}
 
-	function toggleOff() {
-		on = false;
+	function clickContentRight() {
+		on = $$slots['content-left'] ? true : !on;
 	}
 
 	const defaultClass = 'stwui-toggle-wrapper flex flex-col';
 	$: finalClass = twMerge(defaultClass, $$props.class);
 
 	setContext('toggle-name', name);
-	setContext('toggle-on', toggleOn);
-	setContext('toggle-off', toggleOff);
+	setContext('toggle-click-content-left', clickContentLeft);
+	setContext('toggle-click-content-right', clickContentRight);
 </script>
 
 <div


### PR DESCRIPTION
Currently:
1. if a **left** content is specified then clicking on it will switch the Toggle **off**.
2. if a **right** content is specified then clicking on it will switch the Toggle **on**.
3. if **both** side contents are specified then clicking left will switch off and clicking right will switch on.

I believe cases 1 and 2 are counter-intuitive. If there is content defined on one side only I would expect that it's just the name for this variable and that clicking the label would have the same effect as clicking on the Toggle itself.

If there are contents on both sides then I would expect that they are "on/off" labels, therefore case 3 is fine with me.

So I updated the code so that:
1. if a **left** content **only** is specified then clicking on it will switch the Toggle **on and off**.
2. if a **right** content **only** is specified then clicking on it will switch the Toggle **on and off**.
3. if **both** side contents are specified then clicking left will switch off and clicking right will switch on.