### PR TITLE
chore: Run publint during `npm run package`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"scripts": {
 		"dev": "vite dev --open --host",
 		"build": "vite build",
-		"package": "svelte-package -o package",
+		"package": "svelte-package --output ./package && publint --strict",
 		"preview": "vite preview",
 		"test": "vitest",
 		"coverage": "vitest run --coverage",
@@ -29,7 +29,6 @@
 		"lint": "prettier --check . && eslint .",
 		"lint:fix": "eslint --fix .",
 		"format": "prettier --write .",
-		"prepublishOnly": "publint --strict",
 		"publish": "npm publish ./package",
 		"prepare": "husky install && svelte-kit sync",
 		"pack": "node ./scripts/pack"


### PR DESCRIPTION
Follow-on from #202

I've realised that by only running publint on `prepublishOnly`, it will not run on any PRs. Running with `package` should catch issues earlier in development.