### PR TITLE
Issue(datepicker): When setting a min/max date, cannot switch back or switch forward a month when day is lower than min or higher than max

### DIFF
--- a/src/lib/components/datepicker/DatePicker.svelte
+++ b/src/lib/components/datepicker/DatePicker.svelte
@@ -143,12 +143,14 @@
 		if (!minDate && !maxDate) {
 			return true;
 		}
+        const tempMinCalendarDay = calendarDay.set('day', 31);
+        const tempMaxCalendarDay = calendarDay.set('day', 1);
 		if (minDate && maxDate) {
-			return calendarDay.isAfter(minDate) && calendarDay.isBefore(maxDate);
+			return tempMinCalendarDay.isAfter(minDate, 'days') && tempMaxCalendarDay.isBefore(maxDate, 'days');
 		} else if (minDate) {
-			return calendarDay.isAfter(minDate);
+			return tempMinCalendarDay.isAfter(minDate, 'days');
 		} else if (maxDate) {
-			return calendarDay.isBefore(maxDate);
+			return tempMaxCalendarDay.isBefore(maxDate, 'days');
 		}
 		return true;
 	}
@@ -263,17 +265,22 @@
 	}
 
 	function handleArrow(unit: 'year' | 'month', operation: 'add' | 'subtract') {
-		if (unit === 'year') {
-			const newBrowseDate = browseDate[operation](1, 'year');
-			if (dayIsInRange(newBrowseDate)) {
-				setYear(browseDate, operation);
-			}
-		} else if (unit === 'month') {
-			const newBrowseDate = browseDate[operation](1, 'month');
-			if (dayIsInRange(newBrowseDate)) {
-				setMonth(browseDate, operation);
-			}
-		}
+        switch (unit) {
+            case 'year': {
+                const newBrowseDate = browseDate[operation](1, 'year');
+                if (dayIsInRange(newBrowseDate)) {
+                    setYear(browseDate, operation);
+                }
+                break;
+            }
+            case 'month': {
+                const newBrowseDate = browseDate[operation](1, 'month');
+                if (dayIsInRange(newBrowseDate)) {
+                    setMonth(browseDate, operation);
+                }
+                break;
+            }
+        }
 	}
 
 	updateCalendarDays();

--- a/src/lib/utils/formatNumber/index.ts
+++ b/src/lib/utils/formatNumber/index.ts
@@ -21,13 +21,13 @@ export default function formatNumber(
 		minimumFractionDigits: minimumFractionDigits
 			? minimumFractionDigits
 			: style === 'currency'
-			? 2
-			: minimumFractionDigits,
+				? 2
+				: minimumFractionDigits,
 		maximumFractionDigits: maximumFractionDigits
 			? maximumFractionDigits
 			: style === 'currency'
-			? 2
-			: maximumFractionDigits
+				? 2
+				: maximumFractionDigits
 	});
 	return formatter.format(number);
 }

--- a/src/routes/datepicker/+page.svelte
+++ b/src/routes/datepicker/+page.svelte
@@ -85,10 +85,22 @@
 	<CodeBlock slot="code" language="svelte" code={withLabelExample} />
 </ExampleContainer>
 
+<ExampleContainer title={`With day limit (min: ${new Date().toLocaleDateString()})`}>
+	<div slot="preview" class="w-full flex flex-row gap-2 items-center justify-center">
+		<div class="w-full max-w-lg mx-auto">
+			<DatePicker name="date-3" min={new Date()} allowClear class="w-full">
+				<DatePicker.Label slot="label">Date</DatePicker.Label>
+			</DatePicker>
+		</div>
+	</div>
+
+	<CodeBlock slot="code" language="svelte" code={withLabelExample} />
+</ExampleContainer>
+
 <ExampleContainer title="With Leading">
 	<div slot="preview" class="w-full flex flex-row gap-2 items-center justify-center">
 		<div class="w-full max-w-lg mx-auto">
-			<DatePicker name="date-3" allowClear class="w-full">
+			<DatePicker name="date-4" allowClear class="w-full">
 				<DatePicker.Label slot="label">Date</DatePicker.Label>
 				<DatePicker.Leading slot="leading" data={calendar} />
 			</DatePicker>
@@ -101,7 +113,7 @@
 <ExampleContainer title="With Trailing">
 	<div slot="preview" class="w-full flex flex-row gap-2 items-center justify-center">
 		<div class="w-full max-w-lg mx-auto">
-			<DatePicker name="date-4" label="Date" class="w-full">
+			<DatePicker name="date-5" label="Date" class="w-full">
 				<DatePicker.Label slot="label">Date</DatePicker.Label>
 				<DatePicker.Trailing slot="trailing" data={calendar} />
 			</DatePicker>
@@ -114,7 +126,7 @@
 <ExampleContainer title="With Error">
 	<div slot="preview" class="w-full flex flex-row gap-2 items-center justify-center">
 		<div class="w-full max-w-lg mx-auto">
-			<DatePicker name="date-5" label="Date" bind:value {error} class="w-full">
+			<DatePicker name="date-6" label="Date" bind:value {error} class="w-full">
 				<DatePicker.Label slot="label">Date</DatePicker.Label>
 				<DatePicker.Trailing slot="trailing" data={calendar} />
 			</DatePicker>
@@ -127,7 +139,7 @@
 <ExampleContainer title="Disabled">
 	<div slot="preview" class="w-full flex flex-row gap-2 items-center justify-center">
 		<div class="w-full max-w-lg mx-auto">
-			<DatePicker name="date-6" label="Date" disabled class="w-full">
+			<DatePicker name="date-7" label="Date" disabled class="w-full">
 				<DatePicker.Label slot="label">Date</DatePicker.Label>
 				<DatePicker.Trailing slot="trailing" data={calendar} />
 			</DatePicker>
@@ -140,7 +152,7 @@
 <ExampleContainer title="With Time">
 	<div slot="preview" class="w-full flex flex-row gap-2 items-center justify-center">
 		<div class="w-full max-w-lg mx-auto">
-			<DatePicker name="date-7" label="Date" class="w-full" showTime>
+			<DatePicker name="date-8" label="Date" class="w-full" showTime>
 				<DatePicker.Label slot="label">Date</DatePicker.Label>
 				<DatePicker.Trailing slot="trailing" data={calendar} />
 			</DatePicker>
@@ -153,7 +165,7 @@
 <ExampleContainer title="With Time (24 hour)">
 	<div slot="preview" class="w-full flex flex-row gap-2 items-center justify-center">
 		<div class="w-full max-w-lg mx-auto">
-			<DatePicker name="date-7" label="Date" class="w-full" showTime format="MMMM D, YYYY @ H:mm">
+			<DatePicker name="date-9" label="Date" class="w-full" showTime format="MMMM D, YYYY @ H:mm">
 				<DatePicker.Label slot="label">Date</DatePicker.Label>
 				<DatePicker.Trailing slot="trailing" data={calendar} />
 			</DatePicker>
@@ -166,7 +178,7 @@
 <ExampleContainer title="With Time And Step">
 	<div slot="preview" class="w-full flex flex-row gap-2 items-center justify-center">
 		<div class="w-full max-w-lg mx-auto">
-			<DatePicker name="date-7" label="Date" class="w-full" showTime minuteStep={15}>
+			<DatePicker name="date-10" label="Date" class="w-full" showTime minuteStep={15}>
 				<DatePicker.Label slot="label">Date</DatePicker.Label>
 				<DatePicker.Trailing slot="trailing" data={calendar} />
 			</DatePicker>
@@ -181,7 +193,7 @@
 		<div class="w-full max-w-lg mx-auto">
 			<DatePicker
 				bind:value
-				name="date-8"
+				name="date-11"
 				label="Date"
 				class="w-full"
 				actions={[{ label: 'Today', action: handleToday }]}
@@ -199,7 +211,7 @@
 	<div slot="preview" class="w-full flex flex-row gap-2 items-center justify-center">
 		<div class="w-full max-w-lg mx-auto">
 			<DatePicker
-				name="date-10"
+				name="date-12"
 				placeholder="MM/DD/YYYY"
 				class="w-full"
 				allowUserInput
@@ -215,7 +227,7 @@
 	<div slot="preview" class="w-full flex flex-row gap-2 items-center justify-center">
 		<div class="w-full max-w-lg mx-auto">
 			<DatePicker
-				name="date-11"
+				name="date-13"
 				placeholder="MM/DD/YYYY HH:mm"
 				class="w-full"
 				allowUserInput
@@ -231,7 +243,7 @@
 <ExampleContainer title="Mobile">
 	<div slot="preview" class="w-full flex flex-row gap-2 items-center justify-center">
 		<div class="w-full max-w-lg mx-auto">
-			<DatePicker name="date-9" label="Date" class="w-full" mobile>
+			<DatePicker name="date-14" label="Date" class="w-full" mobile>
 				<DatePicker.Label slot="label">Date</DatePicker.Label>
 				<DatePicker.Trailing slot="trailing" data={calendar} />
 			</DatePicker>
@@ -246,7 +258,7 @@
 		<div class="w-full max-w-lg mx-auto">
 			<DatePicker
 				bind:value
-				name="date-9"
+				name="date-14"
 				label="Date"
 				class="w-full"
 				mobile
@@ -264,7 +276,7 @@
 <ExampleContainer title="Mobile With Time">
 	<div slot="preview" class="w-full flex flex-row gap-2 items-center justify-center">
 		<div class="w-full max-w-lg mx-auto">
-			<DatePicker name="date-9" label="Date" class="w-full" mobile showTime>
+			<DatePicker name="date-15" label="Date" class="w-full" mobile showTime>
 				<DatePicker.Label slot="label">Date</DatePicker.Label>
 				<DatePicker.Trailing slot="trailing" data={calendar} />
 			</DatePicker>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,7 +5,8 @@ const config = {
 	kit: {
 		adapter: adapter(),
 		alias: {
-			$lib: './src/lib'		}
+			$lib: './src/lib'
+		}
 	},
 	preprocess: vitePreprocess({
 		postcss: true,


### PR DESCRIPTION
Hi, I've spotted an issue when you set a min Date (let's say for example: 2 feb 2024) and you are looking this date.month + 1 and select, for example, date.day - 1 (so 1 mar 2024), you can't go back because it would check if, for example, 1 feb is less than min date so it's not switching back until we set the day to be in range of date.day..end of month.

To me, it's an issue because it's not even setting the date when we switch to month - 1 (for example), so no bother checking the (min/max) day, set it to the min (or max) and let the client switch back a month. It would be more use-friendly IMHO.

I ran the `format` command for the prettier, added an example on the `/datepicker` route with a min date and I started the "fix" on the date-picker component itself, it's not working as excepted when setting a max date only but it is when setting a min date only (the visuals on the lowest date works only for the previous month, not days tho, so it's kind of a new bug related to the fix).